### PR TITLE
Better handling of permissions and script extensions

### DIFF
--- a/lib/githooks-sync.rb
+++ b/lib/githooks-sync.rb
@@ -9,27 +9,29 @@ module CocoapodsGitHooks
 				Pod::UI.puts "Git repository not found"
 				return
 			end
+            
 			if !File.directory?(".git-hooks")
 				Pod::UI.puts ".git-hooks folder not found, nothing to sync"
 				return
 			end
-			if Dir['.git-hooks/*'].empty?
+            
+            scriptList = Dir['.git-hooks/*']
+            
+			if scriptList.empty?
 				Pod::UI.puts ".git-hooks folder is empty, nothing to sync"
 				return
 			end
+            
 			if !File.directory?(".git/hooks")
 				FileUtils.mkdir ".git/hooks"
 			end
-
-			FileUtils.cp_r(".git-hooks/.", ".git/hooks/")
-			path = ".git/hooks/"
-			Dir.open(path).each do |p|
-				filename = File.basename(p, File.extname(p))
-				if File.extname(p) == ".sh"
-					FileUtils.mv("#{path}/#{p}", "#{path}/#{filename}")
-				end  				
-  				FileUtils.chmod("+x", "#{path}/#{filename}")
-			end
+            
+            scriptList.each do |script|
+                filename = File.basename(script, File.extname(script))
+                hookPath = ".git/hooks/#{filename}"
+                FileUtils.cp(script, hookPath)
+                FileUtils.chmod("+x", hookPath)
+            end
 			Pod::UI.puts "Git hooks synchronized"
 		end
 	end


### PR DESCRIPTION
Currently, githooks is getting list of all files in `.git/hooks` and updating permissions on those files.

This approach has following issues:

1. `pod githooks` command fails if there are other files present in the `.git/hooks` folder provided by git itself like `.git/hooks/applypatch-msg.sample` as these files don't have `.sh` extension
2. Giving execute permissions to all files in the folder can create security implications.

Also, the module assumes that the extension of the files would be `.sh` and not installing the githooks if user wants to use some other script language and wants to use language specific extensions like `.py` for `python`.

This pull request fixes these two issues.